### PR TITLE
feat: Add CMake and Ctest workflow.

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -1,0 +1,31 @@
+name: CMake
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Init submodules
+      run: |
+        git submodule init
+        git submodule update
+
+    - name: Configure CMake
+      run: cmake -B ${{github.workspace}}/build
+
+    - name: Build
+      run: cmake --build ${{github.workspace}}/build
+
+    - name: Test
+      working-directory: ${{github.workspace}}/build
+      run: ctest
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,1 +1,7 @@
+cmake_minimum_required(VERSION 3.20.0)
+
+project(UnitTestExperiments)
+
+include(CTest)
+
 add_subdirectory(examples)

--- a/examples/led_driver_test/CMakeLists.txt
+++ b/examples/led_driver_test/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 3.20.0)
-
 project(led_driver_test)
+
+include(CTest)
 
 # Glob the sources and add them to the app
 FILE(GLOB app_sources *.c)
@@ -16,8 +17,10 @@ target_include_directories(led_driver_test PRIVATE ${WORKSPACE_ROOT}/drivers)
 target_sources(led_driver_test PRIVATE ${app_sources})
 target_sources(led_driver_test PRIVATE ${WORKSPACE_ROOT}/Unity/src/unity.c)
 
+# Add a target so that 'ninja unittest' builds and runs the unit test.
 add_custom_target(
-	test
+	unittest
 	DEPENDS led_driver_test
 	COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/led_driver_test
 )
+add_test(NAME led_driver_test COMMAND ${CMAKE_CURRENT_BINARY_DIR}/led_driver_test)

--- a/examples/led_driver_test/led_test.c
+++ b/examples/led_driver_test/led_test.c
@@ -33,6 +33,5 @@ int main(void)
 
 	RUN_TEST(test_when_led_init_is_called_it_calls_gpio_init_and_returns_success);
 
-	UNITY_END();
-	return 0;
+	return UNITY_END();
 }


### PR DESCRIPTION
Fix CMakeFiles to make ctest work.
Also return UNIT_END() instead of 0 from test main, so that test
failures are treated as failures in ctest.

Signed-off-by: Balaji Srinivasan <balaji.srinivasan@nordicsemi.no>